### PR TITLE
Fix carousel image navigation

### DIFF
--- a/src/components/structure/ImageCarousel.tsx
+++ b/src/components/structure/ImageCarousel.tsx
@@ -18,8 +18,8 @@ const ImageCarousel = ({ images, onImageClick }: ImageCarouselProps) => {
       <Carousel
         opts={{
           loop: true,
-          align: "start",
-          skipSnaps: false,
+          align: "center",
+          containScroll: false,
           dragFree: false
         }}
         className="w-full"

--- a/src/components/structure/ImageModal.tsx
+++ b/src/components/structure/ImageModal.tsx
@@ -10,8 +10,6 @@ import {
   CarouselItem,
 } from "@/components/ui/carousel";
 import { ChevronLeft, ChevronRight } from "lucide-react";
-import Autoplay from "embla-carousel-autoplay";
-import { useEffect } from "react";
 
 interface ImageModalProps {
   isOpen: boolean;
@@ -38,16 +36,12 @@ const ImageModal = ({
 
         <Carousel
           className="w-full"
-          plugins={[
-            Autoplay({
-              delay: 4000,
-              stopOnInteraction: false,
-            }),
-          ]}
           opts={{
             startIndex: selectedIndex,
             loop: true,
-            dragFree: false,
+            align: "center",
+            containScroll: false,
+            dragFree: false
           }}
         >
           <CarouselContent>
@@ -57,6 +51,7 @@ const ImageModal = ({
                   src={modalImage}
                   alt={`Estrutura ${modalIndex + 1}`}
                   className="max-h-[80vh] w-auto object-contain"
+                  loading="lazy"
                 />
               </CarouselItem>
             ))}


### PR DESCRIPTION
Resolve issues with the carousel on mobile devices where image transitions were not functioning correctly, causing the display to freeze on the first image. Ensure smooth navigation between images. [skip gpt_engineer]